### PR TITLE
Shift in-scan logging to DEBUG level and add progress bar instead

### DIFF
--- a/monopix2_daq/fifo_readout.py
+++ b/monopix2_daq/fifo_readout.py
@@ -94,7 +94,7 @@ class FifoReadout(object):
         if self._is_running:
             raise RuntimeError('Readout already running: use stop() before start()')
         self._is_running = True
-        logging.info('Starting FIFO readout...')
+        logging.debug('Starting FIFO readout...')
         self.callback = callback
         self.errback = errback
         self.fill_buffer = fill_buffer
@@ -137,7 +137,7 @@ class FifoReadout(object):
                 if timeout:
                     raise StopTimeout('FIFO stop timeout after %0.1f second(s)' % timeout)
                 else:
-                    logging.warning('FIFO stop timeout')
+                    logging.debug('FIFO stop timeout')
         except StopTimeout as e:
             if self.errback:
                 self.errback(sys.exc_info())
@@ -151,7 +151,7 @@ class FifoReadout(object):
             self.worker_thread.join()
         self.callback = None
         self.errback = None
-        logging.info('Stopped FIFO readout')
+        logging.debug('Stopped FIFO readout')
 
     def print_readout_status(self):
         ret = self.get_discard_count()

--- a/monopix2_daq/monopix2.py
+++ b/monopix2_daq/monopix2.py
@@ -43,7 +43,7 @@ class Monopix2(Dut):
         """
 
         # Initialize logger.
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(name="LF-Monopix2")
         logFormatter = logging.Formatter("%(asctime)s [%(levelname)-5.5s] [%(threadName)-10s] [%(filename)-15s] [%(funcName)-15s] %(message)s")
         fname = mk_fname(ext="log.log")
         fileHandler = logging.FileHandler(fname)
@@ -306,7 +306,7 @@ class Monopix2(Dut):
                 self[k].set_voltage(kwarg[k], unit='V')
                 self.SET_VALUE[k]=kwarg[k]
                 feedback=[self[k].get_voltage(unit='V'), self[k].get_current(unit='mA')]
-                self.logger.info("Set {0:s}={1:.4f} V | Read {2:s}={3:.4f} V ({4:.4f} mA)".format(k, kwarg[k], k, feedback[0], feedback[1]))
+                self.logger.debug("Set {0:s}={1:.4f} V | Read {2:s}={3:.4f} V ({4:.4f} mA)".format(k, kwarg[k], k, feedback[0], feedback[1]))
             else:
                 self.logger.info("{0:s} is not a defined as valid voltage source.".format(k))
 
@@ -458,7 +458,7 @@ class Monopix2(Dut):
         self.SET_VALUE['INJ_HI']=VHi
         self['INJ_LO'].set_voltage(VHi, unit='V')
         self.SET_VALUE['INJ_LO']=VHi
-        self.logger.info("VHi set to {0:.4f} V".format(VHi))
+        self.logger.debug("VHi set to {0:.4f} V".format(VHi))
 
     def set_inj_all(self, inj_high=0.6,
                     inj_n=100, inj_width=15000, inj_delay=10000, 
@@ -503,7 +503,7 @@ class Monopix2(Dut):
         self["inj"]["EN"] = ext_trigger
         
         # Logs the corresponding injection values.
-        self.logger.info("Configuring injection: VHi:{0:.4f}, VLo:{1:s}, REPEAT:{2:d}, DELAY:{3:d}, WIDTH:{4:d}, PHASE:{5:d}, External Trigger:{6:d}".format(
+        self.logger.debug("Configuring injection: VHi:{0:.4f}, VLo:{1:s}, REPEAT:{2:d}, DELAY:{3:d}, WIDTH:{4:d}, PHASE:{5:d}, External Trigger:{6:d}".format(
         self.SET_VALUE['INJ_HI'], "Set on board", self["inj"]["REPEAT"], self["inj"]["DELAY"], self["inj"]["WIDTH"], inj_phase_des, self["inj"]["EN"]))
 
     def start_inj(self):
@@ -511,7 +511,7 @@ class Monopix2(Dut):
         Starts injection into the chip.
         """
         # Starts injection into the chip.
-        self.logger.info("Injecting with parameters: VHi:{0:.4f}, VLo:{1:s}, REPEAT:{2:d}, DELAY:{3:d}, WIDTH:{4:d}, External Trigger:{5:d}".format(
+        self.logger.debug("Injecting with parameters: VHi:{0:.4f}, VLo:{1:s}, REPEAT:{2:d}, DELAY:{3:d}, WIDTH:{4:d}, External Trigger:{5:d}".format(
         self.SET_VALUE['INJ_HI'], "Set on board", self["inj"]["REPEAT"], self["inj"]["DELAY"], self["inj"]["WIDTH"], self["inj"]["EN"]))
         self["inj"].start()
         while self["inj"].is_done() != 1:
@@ -857,7 +857,7 @@ class Monopix2(Dut):
         self._write_pixel_mask(bit="EnInj",mask=mask, overwrite=overwrite)
         
         arg = np.argwhere(self.PIXEL_CONF["EnInj"][:,:])
-        self.logger.info("Enabling Injection for {0:d} pixels: {1:s}".format(len(arg), str(arg).replace("\n", " ")))
+        self.logger.debug("Enabling Injection for {0:d} pixels: {1:s}".format(len(arg), str(arg).replace("\n", " ")))
         
     def set_tdac(self, tdac, overwrite=False):
         #TODO: Maybe better to make this function write all the bit masks only after all four have been changed, and not one by one. 
@@ -1055,7 +1055,7 @@ class Monopix2(Dut):
         #Read-out trash data from the chip
         self['data_rx'].set_en(True)
         time.sleep(0.2)
-        self.logger.info('Setting Monopix Read-out: start_freeze={0:d} start_read={1:d} stop_read={2:0} stop_freeze={3:0} stop={4:0} reset_fifo={5:0}'.format(
+        self.logger.debug('Setting Monopix Read-out: start_freeze={0:d} start_read={1:d} stop_read={2:0} stop_freeze={3:0} stop={4:0} reset_fifo={5:0}'.format(
                      start_freeze, start_read, stop_read, stop_freeze, stop, self['fifo'].get_FIFO_SIZE()))
         # Reset FIFO
         self["fifo"]["RESET"]   # If 'fifo' type: sitcp_fifo 
@@ -1075,7 +1075,7 @@ class Monopix2(Dut):
         if lost_cnt != 0:
             self.logger.warning("Stopping Monopix Read-out: lost_cnt={0:d}".format(lost_cnt))
         #exp=self["data_rx"]["EXPOSURE_TIME"]
-        self.logger.info("Stopping Monopix Read-out: lost_cnt={0:d}".format(lost_cnt))
+        self.logger.debug("Stopping Monopix Read-out: lost_cnt={0:d}".format(lost_cnt))
         self['CONF']['Rst'] = 1
         self['CONF']['ResetBcid'] = 1
         self['CONF']['ClkOut'] = 0

--- a/monopix2_daq/monopix2.py
+++ b/monopix2_daq/monopix2.py
@@ -832,7 +832,7 @@ class Monopix2(Dut):
         self._write_pixel_mask(bit="EnMonitor", mask=mask, overwrite=overwrite)
       
         arg = np.argwhere(self.PIXEL_CONF["EnMonitor"][:, :])
-        self.logger.info("Enabling Monitor for {0:d} pixels:  {1:s}".format(len(arg), str(arg).replace("\n", " ")))
+        self.logger.debug("Enabling Monitor for {0:d} pixels:  {1:s}".format(len(arg), str(arg).replace("\n", " ")))
 
     def set_inj_en(self, pix="none", overwrite=False):
         """
@@ -872,9 +872,9 @@ class Monopix2(Dut):
         mask = np.copy(self.PIXEL_CONF["Trim"])
         if isinstance(tdac, int):
             mask.fill(tdac)
-            self.logger.info("Setting a single TDAC/TRIM value to all pixels: {0:s}".format(str(tdac)))
+            self.logger.debug("Setting a single TDAC/TRIM value to all pixels: {0:s}".format(str(tdac)))
         elif np.shape(tdac) == np.shape(mask):
-            self.logger.info("Setting a TDAC matrix of valid dimensions.")
+            self.logger.debug("Setting a TDAC matrix of valid dimensions.")
             mask = np.array(tdac, dtype=np.uint8)
         else:
             self.logger.error("The input tdac parameter must be int or array of size [{0:d},{1:d}]".format(self.chip_props["COL_SIZE"], self.chip_props["ROW_SIZE"]))
@@ -1171,7 +1171,8 @@ class Monopix2(Dut):
         self["timestamp_{0:s}".format(src)]["ENABLE_EXTERN"] = 0
         self["timestamp_{0:s}".format(src)]["ENABLE"]=0
         lost_cnt=self["timestamp_{0:s}".format(src)]["LOST_COUNT"]
-        self.logger.info("640 MHz sampling disabled for: timestamp_{0:s} (lost_cnt={1:d})".format(src, lost_cnt))
+        if lost_cnt > 0:
+            self.logger.warning("640 MHz sampling disabled for: timestamp_{0:s} (lost_cnt={1:d})".format(src, lost_cnt))
 
     def stop_all_data(self):
         """

--- a/monopix2_daq/scan_base.py
+++ b/monopix2_daq/scan_base.py
@@ -94,7 +94,8 @@ class ScanBase(object):
         self.output_filename = os.path.join(self.working_dir, self.run_name)
         
         # Initialize logger
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(name="LF-Monopix2")
+        self.logger.setLevel(logging.INFO)
         for l in self.logger.handlers:
             if isinstance(l, logging.FileHandler):
                dut_logger_filename=l.baseFilename

--- a/monopix2_daq/scans/scan_minGlobalTH.py
+++ b/monopix2_daq/scans/scan_minGlobalTH.py
@@ -108,16 +108,16 @@ class ScanMinGlobalTH(scan_base.ScanBase):
         
         # Shift global THs and look for noisy pixels.
         while (lowestTH_flag.all() == False):
-            self.logger.info("----- Shifting global thresholds and checking for noisy pixels -----")
-            self.logger.info("Current global thresholds: CSA 1 ({0:.4f} V, Lowest: {1}) | CSA 2 ({2:.4f} V, Lowest: {3}) | CSA 3 ({4:.4f} V, Lowest: {5})".format(
+            self.logger.debug("----- Shifting global thresholds and checking for noisy pixels -----")
+            self.logger.debug("Current global thresholds: CSA 1 ({0:.4f} V, Lowest: {1}) | CSA 2 ({2:.4f} V, Lowest: {3}) | CSA 3 ({4:.4f} V, Lowest: {5})".format(
                 th[0], lowestTH_flag[0], 
                 th[1], lowestTH_flag[1], 
                 th[2], lowestTH_flag[2]))
-            self.logger.info("Noisy pixels in: CSA 1 ({0} / {1}) | CSA 2 ({2} / {3}) | CSA 3 ({4} / {5})".format(
+            self.logger.debug("Noisy pixels in: CSA 1 ({0} / {1}) | CSA 2 ({2} / {3}) | CSA 3 ({4} / {5})".format(
                 current_noisy[0],masked_pixel_limit[0],
                 current_noisy[1],masked_pixel_limit[1],
                 current_noisy[2],masked_pixel_limit[2]))
-            self.logger.info("Current global threshold steps for: CSA 1 ({0} V) | CSA 2 ({1} V) | CSA 3 ({2} V)".format(
+            self.logger.debug("Current global threshold steps for: CSA 1 ({0} V) | CSA 2 ({1} V) | CSA 3 ({2} V)".format(
                 th_step[0],
                 th_step[1],
                 th_step[2]))

--- a/monopix2_daq/scans/scan_threshold.py
+++ b/monopix2_daq/scans/scan_threshold.py
@@ -1,9 +1,7 @@
-import os,sys,time
-import numpy as np
-import bitarray
-import tables as tb
-import yaml
+import time
 import math
+import numpy as np
+from tqdm import tqdm
 
 import monopix2_daq.scan_base as scan_base
 import monopix2_daq.analysis.scan_utils as scan_utils
@@ -134,6 +132,7 @@ class ScanThreshold(scan_base.ScanBase):
         # Start Read-out.
         self.monopix.set_monoread()
 
+        pbar = tqdm(total=len(inj_th_phase) * mask_n, unit=' Masks')
         # Scan over injection steps and record the corresponding hits.
         for inj, phase in inj_th_phase.tolist():
             # Calculate INJ_HI to the desired value, while taking into account the INJ_LO defined in the board.
@@ -186,6 +185,7 @@ class ScanThreshold(scan_base.ScanBase):
                     self.monopix.start_inj()
                     time.sleep(0.05)
                     pre_cnt=cnt
+                pbar.update(1)
 
             self.logger.debug('mask=%d pix=%s data=%d'%(mask_i,str(mask_pix),cnt-pre_cnt))
             
@@ -198,6 +198,7 @@ class ScanThreshold(scan_base.ScanBase):
             pre_cnt=cnt
             cnt=self.fifo_readout.get_record_count()
 
+        pbar.close()
         # Stop read-out and timestamps.
         self.monopix.stop_all_data() 
         

--- a/monopix2_daq/scans/scan_threshold.py
+++ b/monopix2_daq/scans/scan_threshold.py
@@ -39,7 +39,6 @@ class ScanThreshold(scan_base.ScanBase):
             Execute a threshold scan.
             This script scans the injection amplitude over a chip with fixed DAC settings and fits the results to determine the current effective threshold.  
         """
-        debug_flag=False
 
         # Set a hard-coded limit on the maximum  number of pixels injected simultaneously.
         n_mask_pix_limit = 170
@@ -161,7 +160,7 @@ class ScanThreshold(scan_base.ScanBase):
             # Go through the masks.
             for mask_i in range(mask_n):
                 self.monopix.set_preamp_en("none")
-                self.logger.info('Injecting: Mask {0}, from {1:.3f} to {2:.3f} V'.format(scan_param_id,injlist[0], injlist[-1]))
+                self.logger.debug('Injecting: Mask {0}, from {1:.3f} to {2:.3f} V'.format(scan_param_id,injlist[0], injlist[-1]))
                 # Choose the current mask, and enable the corresponding pixels.
                 mask_pix=[]
                 pix_frommask=list_of_masks[mask_i]
@@ -188,8 +187,7 @@ class ScanThreshold(scan_base.ScanBase):
                     time.sleep(0.05)
                     pre_cnt=cnt
 
-            if debug_flag:
-                self.logger.info('mask=%d pix=%s data=%d'%(mask_i,str(mask_pix),cnt-pre_cnt))
+            self.logger.debug('mask=%d pix=%s data=%d'%(mask_i,str(mask_pix),cnt-pre_cnt))
             
             # Increase scan parameter ID counter.
             scan_param_id=scan_param_id+1


### PR DESCRIPTION
This PR shifts in-scan logging which spams the console to DEBUG level. Instead, scan appropriate progress bars are implemented. If the logging is still needed, [it can be set by adjusting the logging level to debug here.](https://github.com/SiLab-Bonn/lf-monopix2-daq/blob/debug_logger/monopix2_daq/scan_base.py#L98) 