### PR TITLE
MAINT: Proper enable_mask and mask-shifting

### DIFF
--- a/monopix2_daq/analysis/scan_utils.py
+++ b/monopix2_daq/analysis/scan_utils.py
@@ -143,57 +143,6 @@ def scurve_from_fit(th, A_fit,mu_fit,sigma_fit,reverse=True,n=500):
     else:
         return x,scurve(x,A_fit,mu_fit,sigma_fit)
 
-def generate_mask(n_cols=COL_SIZE, n_rows=ROW_SIZE, mask_steps=6, return_lists=True):
-    global_mask=[]
-    global_mask_lists=[]
-    for i in range(mask_steps):
-        global_mask.append(np.zeros([n_cols,n_rows], dtype = "u1")) 
-    
-    for step in range(mask_steps):
-        list_even=list(range(step,n_rows,mask_steps))
-        list_odd=list(range(step+int(math.ceil(mask_steps/2.0)),n_rows,mask_steps))
-        if step>=int(math.ceil(mask_steps/2)):
-            list_odd.append(step-int(math.ceil(mask_steps/2)))
-        for col in range(n_cols):
-            if col%2==0:
-                for row in list_even:
-                    global_mask[step][col,row] = 1 
-            else:
-                for row in list_odd:
-                    global_mask[step][col,row] = 1
-        global_mask_lists.append(np.argwhere(global_mask[step][:]==1))
-    if return_lists:
-        return global_mask_lists
-    else:
-        return global_mask
-
-# TODO: Faster way of implementing mask creating using np.roll()
-def generate_mask_per_column(enabled_columns=COL_SIZE, n_rows=ROW_SIZE, step_size=6, return_lists=True):
-    global_mask=[]
-    global_mask_lists=[]
-
-    number_of_masks=step_size*len(enabled_columns)
-    for i in range(number_of_masks):
-        global_mask.append(np.zeros([COL_SIZE,ROW_SIZE], dtype = "u1"))
-    
-    list_rows=[]
-    for step in range(step_size):
-        list_rows.append(list(range(step,n_rows, step_size)))
-
-    mask_n = 0
-    while mask_n < number_of_masks:
-        for col in enabled_columns:
-            for step in range(step_size):
-                for row in list_rows[step]:
-                    global_mask[mask_n][col, row] = 1
-                global_mask_lists.append(np.argwhere(global_mask[mask_n][:]==1))
-                mask_n += 1
-
-    if return_lists:
-        return global_mask_lists
-    else:
-        return global_mask
-
 def get_scurve(f_event,pixel,type="inj"):
     res={}
     dat=f_event.root.Cnts[:]

--- a/monopix2_daq/monopix2.py
+++ b/monopix2_daq/monopix2.py
@@ -713,6 +713,23 @@ class Monopix2(Dut):
             pixconf_exchanged_bit= np.reshape(np.packbits(matrix_in_bits),(self.chip_props["COL_SIZE"], self.chip_props["ROW_SIZE"]))
             self.PIXEL_CONF[bit] = pixconf_exchanged_bit
 
+    def create_shift_pattern(self, step):
+        """ Creates "classic" shift pattern for injection mask
+        """
+        base_mask = np.zeros([self.chip_props["COL_SIZE"], self.chip_props["ROW_SIZE"]], dtype=bool)
+        mask_steps = self.chip_props["COL_SIZE"] * step
+        current_step = 0
+        mask_list = []
+
+        for row in range(0, self.chip_props['ROW_SIZE'], step):
+            base_mask[0, row] = True
+
+        while current_step < mask_steps:
+            mask_list.append(np.roll(np.roll(base_mask, current_step // self.chip_props["COL_SIZE"], 1), current_step % self.chip_props["COL_SIZE"], 0))
+            current_step += 1
+
+        return mask_list
+
     def _create_mask(self, pix):
         """
         Creates a mask of the same dimensions as the chip's dimensions.

--- a/monopix2_daq/scan_base.py
+++ b/monopix2_daq/scan_base.py
@@ -317,7 +317,7 @@ class ScanBase(object):
 
         return conf
 
-    def _init_chip_config(self, config_file=None, th1=None, th2=None, th3=None, flavor=None, **_):
+    def _init_chip_config(self, config_file=None, th1=None, th2=None, th3=None, flavor=None, start_col=None, stop_col=None, start_row=None, stop_row=None, **_):
         ''' Initialize and configure chip, parameters given (mostly) as parser arguments
         '''
         if config_file is not None:
@@ -344,6 +344,11 @@ class ScanBase(object):
                 tmp=flavor.split(":")
                 self.enable_mask[int(tmp[0]):int(tmp[1])] = 1
                 self.monopix.logger.info("Enabled: Columns {0:s} to {1:s}".format(tmp[0], tmp[1]))
+            if config_file is not None or self.configuration['bench']['module']['chip']['chip_config'] is not None:
+                self.enable_mask[~np.array(self.monopix.PIXEL_CONF["EnPre"], bool)] = 0
+
+        elif np.all([start_col, stop_col, start_row, stop_row]) is not None:
+            self.enable_mask[start_col:stop_col, start_row:stop_row] = 1
             if config_file is not None or self.configuration['bench']['module']['chip']['chip_config'] is not None:
                 self.enable_mask[~np.array(self.monopix.PIXEL_CONF["EnPre"], bool)] = 0
 

--- a/monopix2_daq/scan_base.py
+++ b/monopix2_daq/scan_base.py
@@ -334,36 +334,23 @@ class ScanBase(object):
         if th3 is not None:
             self.monopix.set_th(3, th3)
 
+        self.enable_mask = np.zeros((self.monopix.chip_props['COL_SIZE'], self.monopix.chip_props['ROW_SIZE']), dtype=bool)
+
         if flavor is not None:
             if flavor=="all":
-                collist=range(0, self.monopix.chip_props["COL_SIZE"])
+                self.enable_mask[:, :] = 1
                 self.monopix.logger.info("Enabled: Full matrix")
             else:
                 tmp=flavor.split(":")
-                collist=range(int(tmp[0]), int(tmp[1]))
+                self.enable_mask[int(tmp[0]):int(tmp[1])] = 1
                 self.monopix.logger.info("Enabled: Columns {0:s} to {1:s}".format(tmp[0], tmp[1]))
+            if config_file is not None or self.configuration['bench']['module']['chip']['chip_config'] is not None:
+                self.enable_mask[~np.array(self.monopix.PIXEL_CONF["EnPre"], bool)] = 0
 
-            self.pix=[]
-            for i in collist:
-                for j in range(0, self.monopix.chip_props["ROW_SIZE"]):
-                    if config_file is not None or self.configuration['bench']['module']['chip']['chip_config'] is not None:
-                        if self.monopix.PIXEL_CONF["EnPre"][i,j]!=0:
-                            self.pix.append([i,j])
-                        else:
-                            pass
-                    else:
-                            self.pix.append([i,j])
         else:
-            self.pix=[]
-            self.monopix.set_preamp_en(self.monopix.PIXEL_CONF["EnPre"])
+            self.enable_mask = np.array(self.monopix.PIXEL_CONF["EnPre"], bool)
+            self.monopix.set_preamp_en(self.enable_mask)
             self.monopix.set_tdac(self.monopix.PIXEL_CONF["Trim"], overwrite=True)
-            
-            for i in range(0, self.monopix.chip_props["COL_SIZE"]):
-                for j in range(0, self.monopix.chip_props["ROW_SIZE"]):
-                    if self.monopix.PIXEL_CONF["EnPre"][i,j]!=0:
-                        self.pix.append([i,j])
-                    else:
-                        pass
 
     def close(self):
         '''

--- a/monopix2_daq/scans/scan_minGlobalTH.py
+++ b/monopix2_daq/scans/scan_minGlobalTH.py
@@ -34,13 +34,13 @@ class ScanMinGlobalTH(scan_base.ScanBase):
         th = th_start
 
         # Enable pixels.
-        self.monopix.set_preamp_en(self.pix)
+        self.monopix.set_preamp_en(self.enable_mask)
 
         # Enable monitored pixel.
         if monitor_pixel is not None:
             self.monopix.set_mon_en(monitor_pixel, overwrite=True)
         else:
-            self.monopix.set_mon_en(self.pix[0], overwrite=True)
+            self.monopix.set_mon_en([26, 170], overwrite=True)
 
         # Enable timestamps.
         if with_mon:

--- a/monopix2_daq/scans/scan_minGlobalTH.py
+++ b/monopix2_daq/scans/scan_minGlobalTH.py
@@ -21,6 +21,11 @@ local_configuration={
     "th_step": [-0.01,-0.01,-0.01],     # Telescopic steps to reach the minimum global threshold
     "trim_mask": None,                  # TRIM mask (None: Go with TRIM limit, 'middle': Middle TRIM)
     "trim_limit": False,                # TRIM limit (True: High, False: Lowest, "unbiased": Unbiased)
+
+    "start_col": None,
+    "stop_col": None,
+    "start_row": None,
+    "stop_row": None,
 }
 
 class ScanMinGlobalTH(scan_base.ScanBase):
@@ -234,8 +239,9 @@ if __name__ == "__main__":
     
     args=parser.parse_args()
     args.no_power_reset = not bool(args.power_reset)
+    local_configuration.update(vars(args))
     
-    scan = ScanMinGlobalTH(**vars(args))
+    scan = ScanMinGlobalTH(**local_configuration)
     scan.start(**local_configuration)
     scan.analyze()
     scan.plot()

--- a/monopix2_daq/scans/scan_minGlobalTH.py
+++ b/monopix2_daq/scans/scan_minGlobalTH.py
@@ -76,19 +76,8 @@ class ScanMinGlobalTH(scan_base.ScanBase):
         en_ref = np.ones_like(self.monopix.PIXEL_CONF["EnPre"])
         en_where = np.full_like(en_current, True, dtype=bool)
 
-        # Count the total number of masked pixels.
-        orig_pix_n = np.array([0, 0, 0])
-        for col_id, cols in enumerate(en_current):
-            for rows in cols[:]:
-                if rows==1:
-                    if col_id in self.monopix.chip_props["COLS_M1"]:
-                        orig_pix_n[0] += 1
-                    elif col_id in self.monopix.chip_props["COLS_M2"]:
-                        orig_pix_n[1] += 1
-                    elif col_id in self.monopix.chip_props["COLS_M3"]:
-                        orig_pix_n[2] += 1
-                    else:
-                        pass
+        # Count the total number of masked pixels: format [M1, M2, M3].
+        orig_pix_n = np.array([np.count_nonzero(self.enable_mask[16:56]), np.count_nonzero(self.enable_mask[8:16]), np.count_nonzero(self.enable_mask[0:8])])
 
         # Determine the maximum number of noisy/masked pixels in every CSA flavour.
         masked_pixel_limit = (orig_pix_n * mask_factor).astype(int)

--- a/monopix2_daq/scans/scan_minGlobalTH.py
+++ b/monopix2_daq/scans/scan_minGlobalTH.py
@@ -82,7 +82,9 @@ class ScanMinGlobalTH(scan_base.ScanBase):
         en_where = np.full_like(en_current, True, dtype=bool)
 
         # Count the total number of masked pixels: format [M1, M2, M3].
-        orig_pix_n = np.array([np.count_nonzero(self.enable_mask[16:56]), np.count_nonzero(self.enable_mask[8:16]), np.count_nonzero(self.enable_mask[0:8])])
+        orig_pix_n = np.array([np.count_nonzero(self.enable_mask[self.monopix.chip_props["COLS_M1"][0]:self.monopix.chip_props["COLS_M1"][-1]]),
+                               np.count_nonzero(self.enable_mask[self.monopix.chip_props["COLS_M2"][0]:self.monopix.chip_props["COLS_M2"][-1]]),
+                               np.count_nonzero(self.enable_mask[self.monopix.chip_props["COLS_M3"][0]:self.monopix.chip_props["COLS_M3"][-1]])])
 
         # Determine the maximum number of noisy/masked pixels in every CSA flavour.
         masked_pixel_limit = (orig_pix_n * mask_factor).astype(int)

--- a/monopix2_daq/scans/scan_source.py
+++ b/monopix2_daq/scans/scan_source.py
@@ -30,13 +30,13 @@ class ScanSource(scan_base.ScanBase):
         scanned=0
 
         # Enable pixels.
-        self.monopix.set_preamp_en(self.pix)
+        self.monopix.set_preamp_en(self.enable_mask)
 
         # Enable monitored pixel.
         if monitor_pixel is not None:
             self.monopix.set_mon_en(monitor_pixel, overwrite=True)
         else:
-            self.monopix.set_mon_en(self.pix[0], overwrite=True)
+            self.monopix.set_mon_en([26, 140], overwrite=True)
 
         # Enable timestamps.
         if with_tlu:

--- a/monopix2_daq/scans/scan_source.py
+++ b/monopix2_daq/scans/scan_source.py
@@ -16,6 +16,11 @@ local_configuration={
     "monitor_pixel": None,      # Pixel to be monitored. Format: [COL,ROW]
     "scan_time": 10,            # Scan time (in seconds)
     "tlu_delay": 8,             # Delay setting for the TLU (Default for standard cable length: 7 or 8)
+
+    "start_col": None,
+    "stop_col": None,
+    "start_row": None,
+    "stop_row": None,
 }
 
 class ScanSource(scan_base.ScanBase):
@@ -103,16 +108,14 @@ if __name__ == "__main__":
     parser.add_argument('-t3',"--th3", type=float, default=None)
     parser.add_argument("-f","--flavor", type=str, default=None)
     parser.add_argument("-p","--power_reset", action='store_const', const=1, default=0) # Default = True: Skip power reset.
-    parser.add_argument("-time",'--scan_time', type=int, default=None,
+    parser.add_argument("-time","--scan_time", type=int, default=local_configuration["scan_time"],
                         help="Scan time in seconds.")
     
     args=parser.parse_args()
     args.no_power_reset = not bool(args.power_reset)
-
-    if args.scan_time is not None:
-        local_configuration["scan_time"]=args.scan_time
+    local_configuration.update(vars(args))
     
-    scan = ScanSource(**vars(args))
+    scan = ScanSource(**local_configuration)
     scan.start(**local_configuration)
     scan.analyze()
     scan.plot()

--- a/monopix2_daq/scans/scan_threshold.py
+++ b/monopix2_daq/scans/scan_threshold.py
@@ -27,6 +27,11 @@ local_configuration={
     "trim_limit": None,                     # TRIM limit (True: High, False: Lowest, "unbiased": Unbiased)
     "with_calibration": True,               # Determine if calibration is used in the output plots
     "c_inj": 2.76e-15,                      # Injection capacitance value in F
+
+    "start_col": None,
+    "stop_col": None,
+    "start_row": None,
+    "stop_row": None,
 }
 
 class ScanThreshold(scan_base.ScanBase):
@@ -221,8 +226,9 @@ if __name__ == "__main__":
     
     args=parser.parse_args()
     args.no_power_reset = not bool(args.power_reset)
+    local_configuration.update(vars(args))
     
-    scan = ScanThreshold(**vars(args))
+    scan = ScanThreshold(**local_configuration)
     scan.start(**local_configuration)
     scan.analyze()
     scan.plot(**local_configuration)

--- a/monopix2_daq/scans/tune_threshold_inj.py
+++ b/monopix2_daq/scans/tune_threshold_inj.py
@@ -25,6 +25,11 @@ local_configuration={
     "mask_step": None,                      # Number of pixels between injected pixels in the same column (overwrites n_mask_pix if not None)
     "inj_n_param": 100,                     # Number of injection pulses per pixel and step
     "lsb_dac": None,                        # LSB dac value
+
+    "start_col": None,
+    "stop_col": None,
+    "start_row": None,
+    "stop_row": None,
 }
 
 class TuneTHinj(scan_base.ScanBase):
@@ -236,8 +241,9 @@ if __name__ == "__main__":
     
     args=parser.parse_args()
     args.no_power_reset = not bool(args.power_reset)
+    local_configuration.update(vars(args))
     
-    scan = TuneTHinj(**vars(args))
+    scan = TuneTHinj(**local_configuration)
     scan.start(**local_configuration)
     scan.analyze()
     scan.plot(**local_configuration)

--- a/monopix2_daq/scans/tune_threshold_inj.py
+++ b/monopix2_daq/scans/tune_threshold_inj.py
@@ -44,7 +44,7 @@ class TuneTHinj(scan_base.ScanBase):
         occ_acceptance = 0.05
 
         # Enable pixels.
-        self.monopix.set_preamp_en(self.pix)
+        self.monopix.set_preamp_en(self.enable_mask)
 
         # Enable timestamps.
         if with_inj:
@@ -64,24 +64,11 @@ class TuneTHinj(scan_base.ScanBase):
         else:
             phaselist=[self.monopix["inj"].get_phase()]
 
-        # Maybe not necessary
-        # mask_n=int((len(pix)-0.5)/n_mask_pix+1)
-
-        # Determine the number of pixels between the injected pixels for the mask. Limits by the maximum number of injected pixels, if needed.
-        if mask_step is not None:    
-            if mask_step < (math.ceil(len(self.pix)/n_mask_pix_limit)):
-                mask_step = (math.ceil(len(self.pix)/n_mask_pix_limit))
-            else:
-                pass
+        # Create initial list of injection masks
+        if mask_step is not None:
+            inj_mask_list = self.monopix.create_shift_pattern(mask_step)
         else:
-            mask_step = (math.ceil(len(self.pix)/n_mask_pix))
-
-        # Create a list of masks to be applied for every injection step. TODO: check which mask generation to use
-        list_of_masks=scan_utils.generate_mask(n_cols=self.monopix.chip_props["COL_SIZE"], n_rows=self.monopix.chip_props["ROW_SIZE"], mask_steps=mask_step, return_lists=False)
-
-        list_of_masks=scan_utils.generate_mask_per_column(enabled_columns=np.unique([coln[0] for coln in self.pix]), n_rows=self.monopix.chip_props["ROW_SIZE"], step_size=2, return_lists=False)
-        mask_n=len(list_of_masks)
-        n_mask_pix=int(math.ceil(self.monopix.chip_props["ROW_SIZE"]/(mask_step*1.0)) * len(np.unique([coln[0] for coln in self.pix], axis=0)) )
+            inj_mask_list = self.monopix.create_shift_pattern(math.ceil(self.monopix.chip_props['ROW_SIZE'] / n_mask_pix))
 
         # If changed from the initial configuration, set the LSB DAC value.
         if lsb_dac is not None:
@@ -116,7 +103,7 @@ class TuneTHinj(scan_base.ScanBase):
         # Create an empty map that will keep track of the signs for the step in enabled pixels (According to its tuning circuitry). 
         trim_increase_sign = np.zeros(shape=self.monopix.PIXEL_CONF["EnPre"].shape, dtype=np.int16)
 
-        for col in np.unique([coln[0] for coln in self.pix], axis=0):
+        for col in np.unique([coln[0] for coln in np.argwhere(self.enable_mask == 1)], axis=0):
             #Initialize TRIM DAC values in the middle of the range.
             trim_ref[col,0:self.monopix.chip_props["ROW_SIZE"]:1] = 7
             trim_ref[col,0:self.monopix.chip_props["ROW_SIZE"]:2] = 8
@@ -128,37 +115,36 @@ class TuneTHinj(scan_base.ScanBase):
         self.monopix.set_tdac(trim_ref, overwrite=True)
 
         # Run the tuning logic with binary search.
-        pbar = tqdm(total=len(tune_steps) * mask_n, unit=' Masks')
-        cnt=0
+        pbar = tqdm(total=len(tune_steps) * len(inj_mask_list), unit=' Masks')
         for scan_param_id, t_step in enumerate(tune_steps):
             data=np.array([],dtype=np.int32)
             # Start Read-out.
             self.monopix.set_monoread()
             # Go through the masks.
-            for mask_i in range(mask_n):
+            for mask_i in inj_mask_list:
+                mask_i = np.logical_and(mask_i, self.enable_mask)
+                # Skip masks with zero enabled pixels
+                if not np.any(mask_i):
+                    pbar.update(1)
+                    continue
+
                 self.logger.debug('Injecting: Mask {0}, aiming to tune to Injection {1:.3f}V'.format(scan_param_id,inj_target))
-                mask_pix=[]
-                pix_frommask=list_of_masks[mask_i]
-                # Check if the pixel in the mask is enabled originally.
-                for i in range(len(self.pix)):
-                    if pix_frommask[self.pix[i][0], self.pix[i][1]]==1 and en_ref[self.pix[i][0], self.pix[i][1]]==1:
-                        mask_pix.append(self.pix[i])
+
                 # Enable monitors and wait a bit, since the setting seems to couple into the CSA output
                 if with_mon:
-                    self.monopix.set_mon_en(mask_pix[0], overwrite=True)
-                    time.sleep(0.02)    
-                # Enable injection to the pixels.
-                self.monopix.set_inj_en(mask_pix, overwrite=True)
+                    monitor_pix = [int(np.argwhere(mask_i == True)[0][0]), int(np.argwhere(mask_i == True)[0][1])]
+                    self.monopix.set_mon_en(monitor_pix, overwrite=True)
+                    time.sleep(0.05)
+                self.monopix.set_inj_en(mask_i, overwrite=True)
                 if disable_noninjected_pixel:
-                    self.monopix.set_preamp_en(mask_pix, overwrite=True)
-                #mask_pix_tmp=mask_pix
-                #for i in range(n_mask_pix-len(mask_pix)):
-                #    mask_pix_tmp.append([-1,-1])
+                    self.monopix.set_preamp_en(mask_i, overwrite=True)
+
                 # Reset and clear trash hits before injecting.
                 time.sleep(0.01)
                 for _ in range(10):
                     self.monopix["fifo"]["RESET"] 
                     time.sleep(0.002)
+
                 # Inject and get data.
                 buf = self.monopix.get_data()
                 data = np.concatenate((data,buf), axis=None)
@@ -211,12 +197,6 @@ class TuneTHinj(scan_base.ScanBase):
                     elif p[0] in self.monopix.chip_props["COLS_TUNING_BI"]:
                         trim_ref[p[0],p[1]] = min(trim_ref[p[0],p[1]]+1,15) 
             """
-
-            pre_cnt=cnt
-            self.logger.debug('mask=%d pix=%s data=%d'%(mask_i,str(mask_pix),cnt-pre_cnt))
-            time.sleep(0.1)
-            pre_cnt=cnt
-            cnt=self.fifo_readout.get_record_count()
 
             # Update the TDAC for the mask and enable again all the original pixels.
             self.monopix.set_tdac(trim_ref, overwrite=True)

--- a/monopix2_daq/scans/tune_threshold_noise.py
+++ b/monopix2_daq/scans/tune_threshold_noise.py
@@ -220,8 +220,9 @@ if __name__ == "__main__":
     
     args=parser.parse_args()
     args.no_power_reset = not bool(args.power_reset)
+    local_configuration.update(vars(args))
     
-    scan = TuneTHnoise(**vars(args))
+    scan = TuneTHnoise(**local_configuration)
     scan.start(**local_configuration)
     scan.analyze()
     scan.plot(**local_configuration)


### PR DESCRIPTION
This PR omits writing a list of pixels which will be enabled for a scan. Instead, a chip-sized array working as an enabled mask is initialized for every scan. Also the mask shifting for scans using injection is adapted accordingly. 